### PR TITLE
Add support for onopen and onmessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ describe('update counter on SSE', () => {
   let wrapper;
   beforeAll(() => {
     wrapper = mount(<Component />);
+    sources['http://example.com/events'].emitOpen();
   });
 
   it('should initialise counter to 0', () => {
@@ -128,6 +129,12 @@ EventSource(
 ##### `__emitter`
 A reference to the [node `EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter) instance used internally.
 
+##### `onopen`
+See [eventSource.onopen](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/onopen).
+
+##### `onmessage`
+See [eventSource.onmessage](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/onmessage).
+
 ##### `onerror`
 See [eventSource.onerror](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/onerror).
 
@@ -153,7 +160,13 @@ const messageEvent = new MessageEvent('type', {
 source.emit(messageEvent.type, messageEvent);
 ```
 
-##### `emitError(error: Error)`
+#### `emitOpen()`
+Simulates the opening of a connection. It sets the ready state to open and invokes the callback.
+
+##### `emitMessage(message: any)`
+Simulates dispatching of a message, it invokes the `onmessage` callback.
+
+#### `emitError(error: Error)`
 Simulates dispatching an error event on the `EventSource` instance. Causes `onerror` to be called.
 
 *Example (jest)*

--- a/__test__/EventSource.test.js
+++ b/__test__/EventSource.test.js
@@ -90,3 +90,38 @@ describe("error", () => {
     expect(onErrorSpy).toHaveBeenCalledWith(error);
   });
 });
+
+describe("open", () => {
+  let eventSource;
+  let onOpenSpy;
+  beforeAll(() => {
+    onOpenSpy = jest.fn();
+    eventSource = new EventSource(URL);
+    eventSource.onopen = onOpenSpy;
+    eventSource.emitOpen();
+  });
+
+  it("should call onopen", () => {
+    expect(onOpenSpy).toHaveBeenCalled();
+  });
+
+  it("should set readyState to 1 (OPEN)", () => {
+    expect(eventSource.readyState).toBe(1);
+  });
+});
+
+describe("message", () => {
+  let eventSource;
+  let onMessageSpy;
+  const msg = "My message to you";
+  beforeAll(() => {
+    onMessageSpy = jest.fn();
+    eventSource = new EventSource(URL);
+    eventSource.onmessage = onMessageSpy;
+    eventSource.emitMessage(msg);
+  });
+
+  it("should call onmessage", () => {
+    expect(onMessageSpy).toHaveBeenCalledWith(msg);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "jest",
     "build": "babel src/ -d lib/",
     "format": "prettier --write '{src,__tests__}/**/*.js'",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "precommit": "lint-staged"
   },
   "author": "Edoardo Colombo <edo.gcolombo@gmail.com>",

--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -28,7 +28,7 @@ export default class EventSource {
   ) {
     this.url = url;
     this.withCredentials = configuration.withCredentials;
-    this.readyState = 1;
+    this.readyState = 0;
     this.__emitter = new EventEmitter();
     sources[url] = this;
   }
@@ -52,6 +52,19 @@ export default class EventSource {
   emitError(error: any) {
     if (typeof this.onerror === "function") {
       this.onerror(error);
+    }
+  }
+
+  emitOpen() {
+    this.readyState = 1;
+    if (typeof this.onopen === "function") {
+      this.onopen();
+    }
+  }
+
+  emitMessage(message: any) {
+    if (typeof this.onmessage === "function") {
+      this.onmessage(message);
     }
   }
 }


### PR DESCRIPTION
Hey there,

I like your approach a lot and therefore chose to extend it with the APIs I need.
I would love to have support for `onopen` and `onmessage`, I also added some tests.

Please be aware that there is a breaking change included, the ready state is now set to ready only after the `emitOpen` callback is called. I would like to have this behavior as I want to test this on a fine-granular level, I hope this is ok with you. Otherwise, we need to think of alternative APIs here.