### PR TITLE
Add readyState constants

### DIFF
--- a/__test__/Component.test.js
+++ b/__test__/Component.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Component from './Component';
-import { sources } from '../src/EventSource';
+import EventSource, { sources } from '../src/EventSource';
 
 const messageEvent = new MessageEvent('foo', {
   data: '1',
@@ -30,6 +30,6 @@ describe('update counter on SSE', () => {
 
   it('close the EventSource on unmount', () => {
     wrapper.unmount();
-    expect(sources['http://example.com/events'].readyState).toBe(2);
+    expect(sources['http://example.com/events'].readyState).toBe(EventSource.CLOSED);
   });
 });

--- a/__test__/EventSource.test.js
+++ b/__test__/EventSource.test.js
@@ -70,7 +70,7 @@ describe("close", () => {
 
   it("should set readyState to 2 (CLOSED)", () => {
     eventSource.close();
-    expect(eventSource.readyState).toBe(2);
+    expect(eventSource.readyState).toBe(EventSource.CLOSED);
   });
 });
 
@@ -106,7 +106,7 @@ describe("open", () => {
   });
 
   it("should set readyState to 1 (OPEN)", () => {
-    expect(eventSource.readyState).toBe(1);
+    expect(eventSource.readyState).toBe(EventSource.OPEN);
   });
 });
 

--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -14,6 +14,10 @@ const defaultOptions = {
 export const sources: { [key: string]: EventSource } = {};
 
 export default class EventSource {
+  static CONNECTING: ReadyStateType;
+  static OPEN: ReadyStateType;
+  static CLOSED: ReadyStateType;
+
   __emitter: EventEmitter;
   onerror: ?EventHandler;
   onmessage: ?EventHandler;
@@ -68,3 +72,7 @@ export default class EventSource {
     }
   }
 }
+
+EventSource.CONNECTING = 0;
+EventSource.OPEN = 1;
+EventSource.CLOSED = 2;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import EventSource, { sources } from './EventSource';
+import EventSource, { sources } from "./EventSource";
 
 export default EventSource;
 export { sources };


### PR DESCRIPTION
Hi!

I added `CONNECTING`, `OPEN` and `CLOSED` constants of `readyState`. This is the same as implemented in the native `EventSource`, and it helps to improve the readability of the test. 😄 

also see [9.2.2 The EventSource interface](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface) 